### PR TITLE
Implement interleaved sample workflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -178,7 +178,9 @@ if len(SINGLE_LOCAL_SAMPLES) + len(SINGLE_FTP_SAMPLES) > 0:
     include: "rules/checksum/single_checksum.smk"
 
 # Quality filtering rules
-if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) > 0:
+if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len([
+    s for s in SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved'
+]) > 0:
     include: "rules/fastp/paired_fastp.smk"
 
 if len(SINGLE_LOCAL_SAMPLES) + len(SINGLE_FTP_SAMPLES) > 0:

--- a/rules/alignment/paired_align.smk
+++ b/rules/alignment/paired_align.smk
@@ -8,11 +8,11 @@ import re
 def get_align_input(wildcards):
     # Check if the sample is interleaved
     if SAMPLES_DF.loc[wildcards.sample, 'read_type'] == 'interleaved':
-        # Use the split files as input
+        # Use the split files as input and ensure the splitting step was run
         return {
             'r1': get_processing_path(f"{{sample}}/{{sample}}.1.cleaned.fastq.gz"),
             'r2': get_processing_path(f"{{sample}}/{{sample}}.2.cleaned.fastq.gz"),
-            #'split_complete': get_processing_path(f"{{sample}}/split_interleaved_complete.flag")
+            'split_complete': get_processing_path(f"{{sample}}/split_interleaved_complete.flag")
         }
     else:
         # Use the original paired-end files as input
@@ -61,7 +61,7 @@ rule align_paired_end:
         mkdir -p $(dirname {output.stats})
         
         # Determine input file type
-        if [[ -f {input.split_complete} ]]; then
+        if [[ -n "{input.split_complete}" && -f {input.split_complete} ]]; then
             echo "Aligning split interleaved reads for {wildcards.sample}" > {log}
             input_r1={input.r1}
             input_r2={input.r2}
@@ -163,7 +163,7 @@ rule align_paired_end:
         fi
         
         # Create flag file to indicate completion
-        if [[ -f {input.split_complete} ]]; then
+        if [[ -n "{input.split_complete}" && -f {input.split_complete} ]]; then
             sample_type="split interleaved"
         else
             sample_type="paired-end"

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -157,14 +157,14 @@ def get_checksum_flag(sample):
 
 def get_fastp_flag(sample):
     """Get the appropriate fastp flag based on sample type"""
-    if is_paired_end(sample):
+    if is_paired_end(sample) or is_interleaved(sample):
         return get_processing_path(f"{sample}/fastp_paired_complete.flag")
     else:
         return get_processing_path(f"{sample}/fastp_single_complete.flag")
 
 def get_alignment_flag(sample):
     """Get the appropriate alignment flag based on sample type"""
-    if is_paired_end(sample):
+    if is_paired_end(sample) or is_interleaved(sample):
         return get_processing_path(f"{sample}/alignment_paired_complete.flag")
     else:
         return get_processing_path(f"{sample}/alignment_single_complete.flag")

--- a/rules/counting/paired_counts.smk
+++ b/rules/counting/paired_counts.smk
@@ -10,14 +10,14 @@ import re
 def is_valid_paired_run_tag(run_tag):
     # For standard samples that are their own run tag
     if run_tag in SAMPLES_DF.index and run_tag not in RUN_TAGS:
-        return is_paired_end(run_tag)
+        return is_paired_end(run_tag) or is_interleaved(run_tag)
         
     # For actual run tags that group multiple samples
     if run_tag in RUN_TAG_SAMPLES:
         samples = RUN_TAG_SAMPLES[run_tag]
         if samples:
             # Check the first sample in the group to determine type
-            return is_paired_end(samples[0])
+            return is_paired_end(samples[0]) or is_interleaved(samples[0])
     
     # Default case - assume it's not valid for this rule
     return False

--- a/rules/coverage/paired_coverage.smk
+++ b/rules/coverage/paired_coverage.smk
@@ -10,14 +10,14 @@ import re
 def is_valid_paired_run_tag(run_tag):
     # For standard samples that are their own run tag
     if run_tag in SAMPLES_DF.index and run_tag not in RUN_TAGS:
-        return is_paired_end(run_tag)
+        return is_paired_end(run_tag) or is_interleaved(run_tag)
         
     # For actual run tags that group multiple samples
     if run_tag in RUN_TAG_SAMPLES:
         samples = RUN_TAG_SAMPLES[run_tag]
         if samples:
             # Check the first sample in the group to determine type
-            return is_paired_end(samples[0])
+            return is_paired_end(samples[0]) or is_interleaved(samples[0])
     
     # Default case - assume it's not valid for this rule
     return False

--- a/rules/fastp/paired_fastp.smk
+++ b/rules/fastp/paired_fastp.smk
@@ -50,7 +50,7 @@ rule fastp_paired_end:
         mkdir -p $(dirname {output.r1})
         
         # Determine input file type
-        if [[ -f {input.split_complete} ]]; then
+        if [[ -n "{input.split_complete}" && -f {input.split_complete} ]]; then
             echo "Processing split interleaved files for {wildcards.sample}" > {log}
             input_r1={input.r1}
             input_r2={input.r2}
@@ -83,7 +83,7 @@ rule fastp_paired_end:
         fi
         
         # Create flag file to indicate completion
-        if [[ -f {input.split_complete} ]]; then
+        if [[ -n "{input.split_complete}" && -f {input.split_complete} ]]; then
             sample_type="split interleaved"
         else
             sample_type="paired-end"

--- a/rules/fastp/single_fastp.smk
+++ b/rules/fastp/single_fastp.smk
@@ -2,9 +2,15 @@
 Rules for quality filtering with fastp for single-end reads
 """
 import os
+import re
 
 # Rule for fastp processing of single-end reads
 rule fastp_single_end:
+    wildcard_constraints:
+        sample = "|".join([
+            re.escape(s) for s in SAMPLES
+            if SAMPLES_DF.loc[s, 'read_type'] == 'single'
+        ])
     input:
         r = get_fastq_single,
         checksums = get_processing_path("{sample}/checksums_single_verified.flag")

--- a/rules/fastp/split_interleaved.sh
+++ b/rules/fastp/split_interleaved.sh
@@ -7,7 +7,7 @@
 if [ $# -ne 2 ]; then
     echo "Usage: $0 <input_interleaved.fastq.gz> <output_prefix>"
     echo "Example: $0 sample_interleaved.fastq.gz sample"
-    echo "Output: sample_1.fq.gz and sample_2.fq.gz"
+    echo "Output: sample_1.fastq.gz and sample_2.fastq.gz"
     exit 1
 fi
 
@@ -50,19 +50,19 @@ BEGIN {
 echo "Modifying headers and compressing..."
 
 # Process R1 file: modify headers and compress
-awk '{print (NR%4 == 1) ? "@1_" ++i " READ/1": $0}' "$TEMP_DIR/temp_R1.fastq" | gzip > "${OUTPUT_PREFIX}.1.fq.gz"
+awk '{print (NR%4 == 1) ? "@1_" ++i " READ/1": $0}' "$TEMP_DIR/temp_R1.fastq" | gzip > "${OUTPUT_PREFIX}.1.fastq.gz"
 
 # Process R2 file: modify headers and compress
-awk '{print (NR%4 == 1) ? "@1_" ++i " READ/2": $0}' "$TEMP_DIR/temp_R2.fastq" | gzip > "${OUTPUT_PREFIX}.2.fq.gz"
+awk '{print (NR%4 == 1) ? "@1_" ++i " READ/2": $0}' "$TEMP_DIR/temp_R2.fastq" | gzip > "${OUTPUT_PREFIX}.2.fastq.gz"
 
 echo "Done!"
 echo "Created files:"
-echo "  ${OUTPUT_PREFIX}.1.fq.gz"
-echo "  ${OUTPUT_PREFIX}.2.fq.gz"
+echo "  ${OUTPUT_PREFIX}.1.fastq.gz"
+echo "  ${OUTPUT_PREFIX}.2.fastq.gz"
 
 # Optional: show some statistics
-R1_READS=$(zcat "${OUTPUT_PREFIX}.1.fq.gz" | wc -l | awk '{print $1/4}')
-R2_READS=$(zcat "${OUTPUT_PREFIX}.2.fq.gz" | wc -l | awk '{print $1/4}')
+R1_READS=$(zcat "${OUTPUT_PREFIX}.1.fastq.gz" | wc -l | awk '{print $1/4}')
+R2_READS=$(zcat "${OUTPUT_PREFIX}.2.fastq.gz" | wc -l | awk '{print $1/4}')
 
 echo "Statistics:"
 echo "  R1 reads: $R1_READS"

--- a/rules/fastp/split_interleaved.smk
+++ b/rules/fastp/split_interleaved.smk
@@ -3,9 +3,10 @@ rule split_interleaved:
         fastq    = get_fastq_single,
         checksums = get_processing_path("{sample}/checksums_single_verified.flag")
     output:
-        # Match the script’s naming: <prefix>.1.fq.gz and <prefix>.2.fq.gz
-        r1       = get_processing_path("{sample}/{sample}.1.fq.gz"),
-        r2       = get_processing_path("{sample}/{sample}.2.fq.gz"),
+        # Outputs use the standard *.fastq.gz extension so downstream rules can
+        # treat the files just like regular paired-end reads.
+        r1       = get_processing_path("{sample}/{sample}.1.fastq.gz"),
+        r2       = get_processing_path("{sample}/{sample}.2.fastq.gz"),
         flag     = get_processing_path("{sample}/split_interleaved_complete.flag")
     log:
         get_processing_path("{sample}/logs/split_interleaved.log")


### PR DESCRIPTION
## Summary
- split interleaved fastq files to `.1.fastq.gz`/`.2.fastq.gz`
- run fastp and alignment as paired after splitting
- treat interleaved samples as paired for later stages
- avoid running single-end fastp on interleaved data
- update coverage and counting rules for interleaved run tags
- include interleaved samples when importing paired fastp module

## Testing
- `snakemake --version` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e3df04888331b358a79c75c367b9