### PR TITLE
Fix interleaved split flag

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -239,7 +239,12 @@ rule all:
         acquisition_flags = [get_acquisition_flag(sample) for sample in SAMPLES],
         checksum_flags = [get_checksum_flag(sample) for sample in SAMPLES],
         fastp_flags = [get_fastp_flag(sample) for sample in SAMPLES],
-        split_flags = [get_processing_path(f"{sample}/{sample}.1.fastq.gz") for sample in SAMPLES if SAMPLES_DF.loc[sample, 'read_type'] == 'interleaved'],
+        # Completion flags from the interleaved splitting step
+        split_flags = [
+            get_processing_path(f"{sample}/split_interleaved_complete.flag")
+            for sample in SAMPLES
+            if SAMPLES_DF.loc[sample, 'read_type'] == 'interleaved'
+        ],
         alignment_flags = [get_alignment_flag(sample) for sample in SAMPLES],
         
         # Then merge and process all effective samples (run tags or standalone samples)


### PR DESCRIPTION
## Summary
- ensure `rule all` checks for the `split_interleaved_complete.flag`

## Testing
- `snakemake --cores 2 --use-conda -p --configfile test_config.yaml` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863edfe06bc8331bd53b3d7c74e3cee