### PR TITLE
Add nanopore sequencing support

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -118,12 +118,16 @@ PAIRED_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] ==
 PAIRED_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'paired') and (SAMPLES_DF.loc[s, 'source_type'] == 'ftp')]
 SINGLE_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] in ['single', 'interleaved']) and (SAMPLES_DF.loc[s, 'source_type'] == 'local')]
 SINGLE_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] in ['single', 'interleaved']) and (SAMPLES_DF.loc[s, 'source_type'] == 'ftp')]
+NANOPORE_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'nanopore') and (SAMPLES_DF.loc[s, 'source_type'] == 'local')]
+NANOPORE_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'nanopore') and (SAMPLES_DF.loc[s, 'source_type'] == 'ftp')]
 
 # Print sample categorization
 print(f"Paired-end, local samples: {len(PAIRED_LOCAL_SAMPLES)}")
 print(f"Paired-end, FTP samples: {len(PAIRED_FTP_SAMPLES)}")
 print(f"Single-end/Interleaved, local samples: {len(SINGLE_LOCAL_SAMPLES)}")
 print(f"Single-end/Interleaved, FTP samples: {len(SINGLE_FTP_SAMPLES)}")
+print(f"Nanopore, local samples: {len(NANOPORE_LOCAL_SAMPLES)}")
+print(f"Nanopore, FTP samples: {len(NANOPORE_FTP_SAMPLES)}")
 print(f"Run tags to process: {len(RUN_TAGS_TO_PROCESS)}")
 print(f"Effective samples to process: {len(EFFECTIVE_SAMPLES_TO_PROCESS)}")
 
@@ -156,6 +160,9 @@ onstart:
 # Include common functions
 include: "rules/common.smk"
 
+# Determine which run tags are non-nanopore for certain steps
+NON_NANOPORE_EFFECTIVE_SAMPLES = [rt for rt in EFFECTIVE_SAMPLES_TO_PROCESS if not is_nanopore(rt)]
+
 # Conditionally include rules based on sample types
 # Acquisition rules
 if PAIRED_LOCAL_SAMPLES:
@@ -164,17 +171,17 @@ if PAIRED_LOCAL_SAMPLES:
 if PAIRED_FTP_SAMPLES:
     include: "rules/acquisition/ftp_paired.smk"
 
-if SINGLE_LOCAL_SAMPLES:
+if len(SINGLE_LOCAL_SAMPLES) + len(NANOPORE_LOCAL_SAMPLES) > 0:
     include: "rules/acquisition/local_single.smk"
 
-if SINGLE_FTP_SAMPLES:
+if len(SINGLE_FTP_SAMPLES) + len(NANOPORE_FTP_SAMPLES) > 0:
     include: "rules/acquisition/ftp_single.smk"
 
 # Checksum verification rules
 if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) > 0:
     include: "rules/checksum/paired_checksum.smk"
 
-if len(SINGLE_LOCAL_SAMPLES) + len(SINGLE_FTP_SAMPLES) > 0:
+if len(SINGLE_LOCAL_SAMPLES) + len(SINGLE_FTP_SAMPLES) + len(NANOPORE_LOCAL_SAMPLES) + len(NANOPORE_FTP_SAMPLES) > 0:
     include: "rules/checksum/single_checksum.smk"
 
 # Quality filtering rules
@@ -197,33 +204,37 @@ if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len([s for s in SAMPLES
 if len([s for s in SINGLE_LOCAL_SAMPLES + SINGLE_FTP_SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'single']) > 0:
     include: "rules/alignment/single_align.smk"
 
+if len(NANOPORE_LOCAL_SAMPLES) + len(NANOPORE_FTP_SAMPLES) > 0:
+    include: "rules/alignment/nanopore_align.smk"
+
 # BAM merging rule (new module)
 include: "rules/processing/merge_bams.smk"
 
 # Common processing rules
-include: "rules/processing/mark_duplicates.smk"
+if NON_NANOPORE_EFFECTIVE_SAMPLES:
+    include: "rules/processing/mark_duplicates.smk"
 
 # QC rules
 include: "rules/qc/bam_qc.smk"
 
-if any(is_paired_end(run_tag) or is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
+if any((is_paired_end(run_tag) or is_interleaved(run_tag)) and not is_nanopore(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/qc/paired_rnaseq.smk"
 
-if any(is_single_end(run_tag) and ~is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
+if any(is_single_end(run_tag) and not is_nanopore(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/qc/single_rnaseq.smk"
 
 # Coverage track generation rules
 if any(is_paired_end(run_tag) or is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/coverage/paired_coverage.smk"
 
-if any(is_single_end(run_tag) and ~is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
+if any(is_single_end(run_tag) or is_nanopore(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/coverage/single_coverage.smk"
 
 # Feature counting rules
 if any(is_paired_end(run_tag) or is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/counting/paired_counts.smk"
 
-if any(is_single_end(run_tag) and ~is_interleaved(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
+if any(is_single_end(run_tag) or is_nanopore(run_tag) for run_tag in EFFECTIVE_SAMPLES_TO_PROCESS):
     include: "rules/counting/single_counts.smk"
 
 # Benchmarking rules

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,11 @@ cores_default: 1
 max_cores: 8
 feature_type: "CDS"
 
+# Nanopore-specific settings
+nanopore_preset: "map-ont"        # Minimap2 preset for nanopore
+cores_nanopore_align: 8           # Cores for nanopore alignment
+mem_nanopore_align: 16000         # Memory for nanopore alignment (MB)
+
 # Mark Duplicates parameters
 remove_duplicates: False  # Set to true to remove duplicates, false to only mark them
 

--- a/envs/nanopore_alignment.yaml
+++ b/envs/nanopore_alignment.yaml
@@ -1,0 +1,8 @@
+name: nanopore_alignment
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - minimap2=2.26
+  - samtools=1.21

--- a/rules/alignment/nanopore_align.smk
+++ b/rules/alignment/nanopore_align.smk
@@ -1,0 +1,67 @@
+"""
+Rules for alignment of nanopore reads using minimap2
+Skip fastp and mark duplicates.
+"""
+import os
+import re
+
+def get_nanopore_align_input(wildcards):
+    return {
+        'r': get_nanopore_fastq(wildcards),
+        'checksums': get_processing_path(f"{wildcards.sample}/checksums_single_verified.flag")
+    }
+
+rule align_nanopore:
+    wildcard_constraints:
+        sample = "|".join([re.escape(s) for s in NANOPORE_LOCAL_SAMPLES + NANOPORE_FTP_SAMPLES]) if NANOPORE_LOCAL_SAMPLES + NANOPORE_FTP_SAMPLES else "^$"
+    input:
+        unpack(get_nanopore_align_input)
+    output:
+        bam = get_processing_path("{sample}/{sample}.bam"),
+        bai = get_processing_path("{sample}/{sample}.bam.bai"),
+        stats = get_processing_path("{sample}/qc/minimap2/{sample}.minimap2_stats.txt"),
+        flag = get_processing_path("{sample}/alignment_single_complete.flag")
+    params:
+        preset = config.get("nanopore_preset", "map-ont"),
+        genome_index = config["processing_genome_index"],
+        rg_id = lambda wc: wc.sample,
+        rg_sm = lambda wc: wc.sample,
+        rg_lb = lambda wc: f"{wc.sample}_lib",
+        rg_pu = lambda wc: f"{wc.sample}_unit",
+        rg_pl = "ONT"
+    log:
+        get_processing_path("{sample}/logs/alignment_nanopore.log")
+    benchmark:
+        get_processing_path("{sample}/benchmarks/align_nanopore.benchmark.txt")
+    threads:
+        config.get("cores_nanopore_align", 8)
+    resources:
+        mem_mb = config.get("mem_nanopore_align", 16000)
+    conda:
+        "../../envs/nanopore_alignment.yaml"
+    singularity:
+        config.get("singularity_image", "")
+    shell:
+        """
+        mkdir -p $(dirname {log})
+        mkdir -p $(dirname {output.bam})
+        mkdir -p $(dirname {output.stats})
+
+        echo "Aligning nanopore reads for {wildcards.sample}" > {log}
+        echo "Input FASTQ: {input.r}" >> {log}
+        echo "Using preset: {params.preset}" >> {log}
+        echo "Genome index base: {params.genome_index}" >> {log}
+
+        minimap2 -ax {params.preset} -t {threads} \
+            -R '@RG\tID:{params.rg_id}\tSM:{params.rg_sm}\tLB:{params.rg_lb}\tPU:{params.rg_pu}\tPL:{params.rg_pl}' \
+            {params.genome_index} {input.r} 2> {output.stats} | \
+            samtools view -bSu -@ {threads} | \
+            samtools sort -@ {threads} -o {output.bam} >> {log} 2>&1
+
+        samtools index -@ {threads} {output.bam}
+
+        echo "Alignment complete for {wildcards.sample}" > {output.flag}
+        echo "Timestamp: $(date)" >> {output.flag}
+        echo "BAM: {output.bam}" >> {output.flag}
+        echo "Stats: {output.stats}" >> {output.flag}
+        """

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -84,6 +84,12 @@ def is_single_end(sample_or_run_tag):
         return get_run_tag_read_type(sample_or_run_tag) == 'single'
     return get_read_type(sample_or_run_tag) == 'single'
 
+def is_nanopore(sample_or_run_tag):
+    """Check if sample or run tag is nanopore"""
+    if is_run_tag(sample_or_run_tag):
+        return get_run_tag_read_type(sample_or_run_tag) == 'nanopore'
+    return get_read_type(sample_or_run_tag) == 'nanopore'
+
 def is_local_source(sample):
     """Check if sample source is local"""
     return get_source_type(sample) == 'local'
@@ -105,6 +111,11 @@ def get_fastq_r2(wildcards):
 
 def get_fastq_single(wildcards):
     """Get the fastq file for a single-end sample"""
+    sample = wildcards.sample
+    return get_processing_path(f"{sample}/{sample}.fastq.gz")
+
+def get_nanopore_fastq(wildcards):
+    """Get the fastq file for a nanopore sample"""
     sample = wildcards.sample
     return get_processing_path(f"{sample}/{sample}.fastq.gz")
 
@@ -138,6 +149,10 @@ def get_aligned_bam(wildcards):
 def get_picard_bam(wildcards):
     """Get the BAM file after processing with Picard MarkDuplicates"""
     run_tag = wildcards.run_tag if hasattr(wildcards, 'run_tag') else wildcards.sample
+
+    if is_nanopore(run_tag):
+        # Nanopore samples skip mark duplicates
+        return get_processing_path(f"merged/{run_tag}/{run_tag}.bam")
     return get_processing_path(f"{run_tag}/{run_tag}.picard.bam")
 
 # Helper functions for flag file paths with specific types
@@ -157,7 +172,10 @@ def get_checksum_flag(sample):
 
 def get_fastp_flag(sample):
     """Get the appropriate fastp flag based on sample type"""
-    if is_paired_end(sample) or is_interleaved(sample):
+    if is_nanopore(sample):
+        # For nanopore samples, use checksum flag instead
+        return get_checksum_flag(sample)
+    elif is_paired_end(sample) or is_interleaved(sample):
         return get_processing_path(f"{sample}/fastp_paired_complete.flag")
     else:
         return get_processing_path(f"{sample}/fastp_single_complete.flag")
@@ -175,7 +193,9 @@ def get_merge_flag(run_tag):
 
 def get_qc_flag(run_tag):
     """Get the appropriate QC flag based on run tag type"""
-    if is_paired_end(run_tag) or is_interleaved(run_tag):
+    if is_nanopore(run_tag):
+        return get_processing_path(f"{run_tag}/bamqc_complete.flag")
+    elif is_paired_end(run_tag) or is_interleaved(run_tag):
         return get_processing_path(f"{run_tag}/qc_paired_complete.flag")
     else:
         return get_processing_path(f"{run_tag}/qc_single_complete.flag")
@@ -196,6 +216,8 @@ def get_featurecounts_flag(run_tag):
 
 def get_markduplicates_flag(run_tag):
     """Get the mark duplicates flag for a run tag"""
+    if is_nanopore(run_tag):
+        return get_merge_flag(run_tag)
     return get_processing_path(f"{run_tag}/markduplicates_complete.flag")
     
     

--- a/rules/counting/single_counts.smk
+++ b/rules/counting/single_counts.smk
@@ -10,14 +10,14 @@ import re
 def is_valid_single_run_tag(run_tag):
     # For standard samples that are their own run tag
     if run_tag in SAMPLES_DF.index and run_tag not in RUN_TAGS:
-        return is_single_end(run_tag)
+        return is_single_end(run_tag) or is_nanopore(run_tag)
         
     # For actual run tags that group multiple samples
     if run_tag in RUN_TAG_SAMPLES:
         samples = RUN_TAG_SAMPLES[run_tag]
         if samples:
             # Check the first sample in the group to determine type
-            return is_single_end(samples[0])
+            return is_single_end(samples[0]) or is_nanopore(samples[0])
     
     # Default case - assume it's not valid for this rule
     return False

--- a/rules/coverage/single_coverage.smk
+++ b/rules/coverage/single_coverage.smk
@@ -10,14 +10,14 @@ import re
 def is_valid_single_run_tag(run_tag):
     # For standard samples that are their own run tag
     if run_tag in SAMPLES_DF.index and run_tag not in RUN_TAGS:
-        return is_single_end(run_tag)
+        return is_single_end(run_tag) or is_nanopore(run_tag)
         
     # For actual run tags that group multiple samples
     if run_tag in RUN_TAG_SAMPLES:
         samples = RUN_TAG_SAMPLES[run_tag]
         if samples:
             # Check the first sample in the group to determine type
-            return is_single_end(samples[0])
+            return is_single_end(samples[0]) or is_nanopore(samples[0])
     
     # Default case - assume it's not valid for this rule
     return False

--- a/rules/sample_utils.py
+++ b/rules/sample_utils.py
@@ -142,7 +142,7 @@ def load_samples(config):
             raise ValueError(error_msg)        
         
         # Validate read_type values
-        valid_read_types = ['single', 'paired', 'interleaved']
+        valid_read_types = ['single', 'paired', 'interleaved', 'nanopore']
         invalid_read_types = samples_df[~samples_df['read_type'].isin(valid_read_types)]['read_type'].unique()
         
         if len(invalid_read_types) > 0:
@@ -163,7 +163,7 @@ def load_samples(config):
                 if pd.isna(row.get('file_path_1', None)) or pd.isna(row.get('file_path_2', None)):
                     print(f"Error: Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
                     raise ValueError(f"Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
-            else:  # single-end or interleaved
+            else:  # single-end, interleaved, or nanopore
                 if pd.isna(row.get('file_path_1', None)):
                     print(f"Error: Missing file_path_1 for {row['read_type']} sample {row['sample_name']}")
                     raise ValueError(f"Missing file_path_1 for {row['read_type']} sample {row['sample_name']}")


### PR DESCRIPTION
## Summary
- add minimap2 environment for nanopore alignment
- support nanopore read type in sample validation
- allow skipping fastp and mark-duplicates when reads are nanopore
- create nanopore alignment rule using minimap2
- integrate nanopore samples throughout the workflow

## Testing
- `snakemake --cores 1 -n --configfile test_config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68664793ceb48331b3dd91213abade17