### PR TITLE
Fix nanopore acquisition

### DIFF
--- a/rules/acquisition/ftp_single.smk
+++ b/rules/acquisition/ftp_single.smk
@@ -7,7 +7,9 @@ import re
 
 rule download_ftp_single_file:
     wildcard_constraints:
-        sample = "|".join([re.escape(s) for s in SINGLE_FTP_SAMPLES])
+        sample = "|".join([
+            re.escape(s) for s in SINGLE_FTP_SAMPLES + NANOPORE_FTP_SAMPLES
+        ])
     output:
         r = get_processing_path("{sample}/{sample}.fastq.gz"),
         flag = get_processing_path("{sample}/acquisition_single_complete.flag")

--- a/rules/acquisition/local_single.smk
+++ b/rules/acquisition/local_single.smk
@@ -8,7 +8,9 @@ import re
 
 rule copy_local_single_file:
     wildcard_constraints:
-        sample = "|".join([re.escape(s) for s in SINGLE_LOCAL_SAMPLES])
+        sample = "|".join([
+            re.escape(s) for s in SINGLE_LOCAL_SAMPLES + NANOPORE_LOCAL_SAMPLES
+        ])
     output:
         r = get_processing_path("{sample}/{sample}.fastq.gz"),
         flag = get_processing_path("{sample}/acquisition_single_complete.flag")


### PR DESCRIPTION
## Summary
- handle local/FTP nanopore samples in the acquisition rules

## Testing
- `pytest -q`
- `snakemake --cores 90 --use-singularity --dry-run --config processing_dir='processing' samples_csv='test_samples.csv' results_dir='tests/test_results' cleanup_processing='true'  processing_dir="processing"`

------
https://chatgpt.com/codex/tasks/task_e_68665499c11483318e1fa4e888a5f02f