### PR TITLE
Fix nanopore FASTA usage

### DIFF
--- a/rules/acquisition/ftp_single.smk
+++ b/rules/acquisition/ftp_single.smk
@@ -7,7 +7,9 @@ import re
 
 rule download_ftp_single_file:
     wildcard_constraints:
-        sample = "|".join([re.escape(s) for s in SINGLE_FTP_SAMPLES])
+        sample = "|".join([
+            re.escape(s) for s in SINGLE_FTP_SAMPLES + NANOPORE_FTP_SAMPLES
+        ])
     output:
         r = get_processing_path("{sample}/{sample}.fastq.gz"),
         flag = get_processing_path("{sample}/acquisition_single_complete.flag")

--- a/rules/acquisition/local_single.smk
+++ b/rules/acquisition/local_single.smk
@@ -8,7 +8,9 @@ import re
 
 rule copy_local_single_file:
     wildcard_constraints:
-        sample = "|".join([re.escape(s) for s in SINGLE_LOCAL_SAMPLES])
+        sample = "|".join([
+            re.escape(s) for s in SINGLE_LOCAL_SAMPLES + NANOPORE_LOCAL_SAMPLES
+        ])
     output:
         r = get_processing_path("{sample}/{sample}.fastq.gz"),
         flag = get_processing_path("{sample}/acquisition_single_complete.flag")

--- a/rules/alignment/nanopore_align.smk
+++ b/rules/alignment/nanopore_align.smk
@@ -50,11 +50,11 @@ rule align_nanopore:
         echo "Aligning nanopore reads for {wildcards.sample}" > {log}
         echo "Input FASTQ: {input.r}" >> {log}
         echo "Using preset: {params.preset}" >> {log}
-        echo "Genome index base: {params.genome_index}" >> {log}
+        echo "Genome FASTA: {params.genome_index}.fa" >> {log}
 
         minimap2 -ax {params.preset} -t {threads} \
             -R '@RG\tID:{params.rg_id}\tSM:{params.rg_sm}\tLB:{params.rg_lb}\tPU:{params.rg_pu}\tPL:{params.rg_pl}' \
-            {params.genome_index} {input.r} 2> {output.stats} | \
+            {params.genome_index}.fa {input.r} 2> {output.stats} | \
             samtools view -bSu -@ {threads} | \
             samtools sort -@ {threads} -o {output.bam} >> {log} 2>&1
 

--- a/rules/sample_utils.py
+++ b/rules/sample_utils.py
@@ -46,8 +46,10 @@ def copy_reference_files(config):
     
     # Copy all genome index files
     # BT2 index files have extensions like .1.bt2, .2.bt2, etc.
-    index_extensions = ['.1.bt2', '.2.bt2', '.3.bt2', '.4.bt2', '.rev.1.bt2', '.rev.2.bt2',
-                        '.1.bt2l', '.2.bt2l', '.3.bt2l', '.4.bt2l', '.rev.1.bt2l', '.rev.2.bt2l']
+    index_extensions = [
+        '.1.bt2', '.2.bt2', '.3.bt2', '.4.bt2', '.rev.1.bt2', '.rev.2.bt2',
+        '.1.bt2l', '.2.bt2l', '.3.bt2l', '.4.bt2l', '.rev.1.bt2l', '.rev.2.bt2l'
+    ]
     
     for ext in index_extensions:
         src_file = src_genome_index_base + ext
@@ -59,6 +61,16 @@ def copy_reference_files(config):
                 shutil.copy2(src_file, target_file)
             except Exception as e:
                 print(f"Warning: Failed to copy genome index file {src_file}: {e}")
+
+    # Copy reference FASTA file for tools like minimap2
+    src_fasta = src_genome_index_base + '.fa'
+    target_fasta = target_genome_base + '.fa'
+    if os.path.exists(src_fasta) and not os.path.exists(target_fasta):
+        print(f"Copying FASTA file from {src_fasta} to {target_fasta}")
+        try:
+            shutil.copy2(src_fasta, target_fasta)
+        except Exception as e:
+            print(f"Warning: Failed to copy FASTA file {src_fasta}: {e}")
 
 def create_sample_directories(config, sample_name):
     """Create the necessary directory structure for a specific sample"""


### PR DESCRIPTION
## Summary
- copy reference FASTA alongside bowtie index
- use the FASTA file when aligning nanopore reads with minimap2

## Testing
- `pytest -q`
- `snakemake --cores 90 --use-singularity --dry-run --config processing_dir='processing' samples_csv='test_samples.csv' results_dir='tests/test_results' cleanup_processing='true' processing_dir="processing"`

------
https://chatgpt.com/codex/tasks/task_e_68665499c11483318e1fa4e888a5f02f