### PR TITLE
Fix nanopore MarkDuplicates skipping

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -214,8 +214,13 @@ def get_featurecounts_flag(run_tag):
     else:
         return get_processing_path(f"{run_tag}/featurecounts_single_complete.flag")
 
-def get_markduplicates_flag(run_tag):
-    """Get the mark duplicates flag for a run tag"""
+def get_markduplicates_flag(wildcards):
+    """Get the mark duplicates flag for a run tag or sample."""
+    if isinstance(wildcards, dict):
+        run_tag = wildcards.get("run_tag") or wildcards.get("sample")
+    else:
+        run_tag = getattr(wildcards, "run_tag", getattr(wildcards, "sample", wildcards))
+
     if is_nanopore(run_tag):
         return get_merge_flag(run_tag)
     return get_processing_path(f"{run_tag}/markduplicates_complete.flag")

--- a/rules/qc/bam_qc.smk
+++ b/rules/qc/bam_qc.smk
@@ -12,7 +12,7 @@ rule samtools_flagstat:
     input:
         bam = get_picard_bam,
         bai = lambda wildcards: f"{get_picard_bam(wildcards)}.bai",
-        markduplicates_flag = get_processing_path("{sample}/markduplicates_complete.flag")
+        markduplicates_flag = get_markduplicates_flag
     output:
         flagstat = get_processing_path("{sample}/qc/flagstat/{sample}.flagstat.txt")
     log:
@@ -53,7 +53,7 @@ rule samtools_stats:
     input:
         bam = get_picard_bam,
         bai = lambda wildcards: f"{get_picard_bam(wildcards)}.bai",
-        markduplicates_flag = get_processing_path("{sample}/markduplicates_complete.flag")
+        markduplicates_flag = get_markduplicates_flag
     output:
         stats = get_processing_path("{sample}/qc/stats/{sample}.stats.txt")
     log:
@@ -94,7 +94,7 @@ rule qualimap_bamqc:
     input:
         bam = get_picard_bam,
         bai = lambda wildcards: f"{get_picard_bam(wildcards)}.bai",
-        markduplicates_flag = get_processing_path("{sample}/markduplicates_complete.flag")
+        markduplicates_flag = get_markduplicates_flag
     output:
         dir = directory(get_processing_path("{sample}/qc/{sample}_qualimap_bam/")),
         flag = get_processing_path("{sample}/bamqc_complete.flag")


### PR DESCRIPTION
## Summary
- adjust `get_markduplicates_flag` to accept wildcards
- ensure QC rules use the helper so MarkDuplicates is skipped for nanopore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68665eceab4083319fa254ee775950aa