### PR TITLE
Skip Qualimap QC for nanopore samples

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -194,7 +194,8 @@ def get_merge_flag(run_tag):
 def get_qc_flag(run_tag):
     """Get the appropriate QC flag based on run tag type"""
     if is_nanopore(run_tag):
-        return get_processing_path(f"{run_tag}/bamqc_complete.flag")
+        # Nanopore samples skip Qualimap QC, so rely on the merge step instead
+        return get_merge_flag(run_tag)
     elif is_paired_end(run_tag) or is_interleaved(run_tag):
         return get_processing_path(f"{run_tag}/qc_paired_complete.flag")
     else:

--- a/rules/qc/bam_qc.smk
+++ b/rules/qc/bam_qc.smk
@@ -6,6 +6,10 @@ Includes:
 - qualimap bamqc
 """
 import os
+import re
+
+# List of samples that are not nanopore
+NON_NANOPORE_SAMPLES = [s for s in SAMPLES if not is_nanopore(s)]
 
 # Rule for running samtools flagstat
 rule samtools_flagstat:
@@ -91,6 +95,8 @@ rule samtools_stats:
 
 # Rule for running qualimap bamqc
 rule qualimap_bamqc:
+    wildcard_constraints:
+        sample = "|".join([re.escape(s) for s in NON_NANOPORE_SAMPLES]) if NON_NANOPORE_SAMPLES else "^$"
     input:
         bam = get_picard_bam,
         bai = lambda wildcards: f"{get_picard_bam(wildcards)}.bai",


### PR DESCRIPTION
## Summary
- avoid Qualimap BAM QC for nanopore data
- use merge flag as QC completion marker for nanopore samples so later rules don't wait for non-existent BAM QC output

## Testing
- `snakemake --cores 2 --use-conda -p --configfile test_config.yaml` *(fails: conda not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666cb74d348331b1ff0a7ac3c30ab2