### PR TITLE
Remove project benchmark merge step

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ results/
 │   │   └── feature_counts/                # featureCounts summaries
 │   ├── benchmarks/                        # Performance benchmarks (optional)
 │   └── logs/                              # Log files (optional)
-├── benchmarks_project_summary.txt         # Project-wide benchmark summary
 └── copy_complete_all.txt                  # Pipeline completion marker
 ```
 

--- a/rules/benchmarks.smk
+++ b/rules/benchmarks.smk
@@ -116,36 +116,3 @@ rule merge_benchmarks_summary:
         echo "Benchmark summary created successfully" >> {log}
         """
 
-# Rule for combining all run tag benchmark summaries into a project-wide report - MODIFIED
-rule merge_benchmarks_all:
-    input:
-        summaries = expand(get_processing_path("{run_tag}/benchmarks_summary.txt"), run_tag=EFFECTIVE_SAMPLES_TO_PROCESS)
-    output:
-        project_report = get_processing_path("benchmarks_project_summary.txt")
-    params:
-        # Pre-calculate the number of samples and run tags
-        num_samples = len(SAMPLES),
-        num_run_tags = len(EFFECTIVE_SAMPLES_TO_PROCESS)
-    log:
-        get_processing_path("logs/benchmarks_project_summary.log")
-    run:
-        # Python code block instead of shell to avoid complex shell scripting
-        import os
-        from datetime import datetime
-        
-        # Create log directory
-        os.makedirs(os.path.dirname(log[0]), exist_ok=True)
-        
-        # Start logging
-        with open(log[0], 'w') as log_file:
-            log_file.write("Creating project-wide benchmark summary\n")
-        
-        # Create header for project report - ONLY KEEP THE FIRST TWO LINES
-        with open(output.project_report, 'w') as report:
-            report.write("PROJECT-WIDE BENCHMARK SUMMARY\n")
-            report.write(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
-            # All other content has been removed
-        
-        # Append to log that we finished
-        with open(log[0], 'a') as log_file:
-            log_file.write("Project benchmark summary created successfully\n")

--- a/rules/results.smk
+++ b/rules/results.smk
@@ -341,11 +341,9 @@ rule copy_results:
 rule copy_results_all:
     input:
         sample_copies = expand(get_results_path("{run_tag}/copy_complete.txt"), run_tag=EFFECTIVE_SAMPLES_TO_PROCESS),
-        benchmark_report = get_processing_path("benchmarks_project_summary.txt")
     output:
         project_complete = get_results_path("copy_complete_all.txt")
     params:
-        benchmark_dest = get_results_path("benchmarks_project_summary.txt"),
         num_samples = len(SAMPLES),
         num_run_tags = len(EFFECTIVE_SAMPLES_TO_PROCESS),
         copy_fastq = config.get("copy_fastq", False),
@@ -358,8 +356,6 @@ rule copy_results_all:
         # Create log directory
         mkdir -p $(dirname {log})
         
-        # Copy the project-wide benchmark summary
-        cp {input.benchmark_report} {params.benchmark_dest} 2>> {log}
         
         # Create completion file
         echo "All results have been copied to the results directory" > {output.project_complete}


### PR DESCRIPTION
## Summary
- drop project-wide benchmark summary rule
- stop copying the summary in `copy_results_all`
- update docs to reflect no project benchmark report

## Testing
- `snakemake --dry-run --config processing_dir="tests/test_counts/test_out/processing" results_dir="tests/test_counts/test_out/results" benchmark_dir="tests/test_counts/test_out/benchmarks" genome_index="tests/test_counts/genome/random_genome" gtf_file="tests/test_counts/genome/annotation.gtf" samples_csv="test_samples_counts_local.csv" cleanup_processing='True'`


------
https://chatgpt.com/codex/tasks/task_e_686b9e04156083318e02d2c568d7cf88