### PR TITLE
Cleanup reference dir when cleanup enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ copy_fastq: false        # Whether to copy FASTQ files to results
 copy_bam: false          # Whether to copy BAM files to results
 copy_benchmarks: true    # Whether to copy benchmark files
 copy_logs: true          # Whether to copy log files
-cleanup_processing: false  # Whether to remove processing directory after completion
+cleanup_processing: false  # Remove processing directory and reference after completion
 
 # Container support
 singularity_image: "/path/to/container.sif"
@@ -291,6 +291,9 @@ results/
 │   └── logs/                              # Log files (optional)
 └── copy_complete_all.txt                  # Pipeline completion marker
 ```
+
+If `cleanup_processing` is enabled, the pipeline also removes the `processing/reference`
+directory after this marker file is written.
 
 ## Run Tags and Sample Grouping
 

--- a/rules/results.smk
+++ b/rules/results.smk
@@ -348,7 +348,8 @@ rule copy_results_all:
         num_run_tags = len(EFFECTIVE_SAMPLES_TO_PROCESS),
         copy_fastq = config.get("copy_fastq", False),
         copy_bam = config.get("copy_bam", False),
-        cleanup_processing = config.get("cleanup_processing", False)
+        cleanup_processing = str(config.get("cleanup_processing", False)).lower(),
+        reference_dir = get_processing_path("reference")
     log:
         get_results_path("logs/copy_results_all.log")
     shell:
@@ -371,4 +372,33 @@ rule copy_results_all:
         echo "Completed copying all results" > {log}
         echo "Timestamp: $(date)" >> {log}
         echo "All individual copy operations completed successfully" >> {log}
+
+        # Remove reference directory if cleanup is enabled
+        if [ "{params.cleanup_processing}" = "true" ]; then
+            if [ -d "{params.reference_dir}" ]; then
+                echo "Removing reference directory: {params.reference_dir}" >> {log}
+
+                # Remove contents first
+                rm -rf "{params.reference_dir}"/* 2>> {log}
+                rm -rf "{params.reference_dir}"/.[!.]* 2>> {log}
+
+                # Then remove the directory itself
+                rmdir "{params.reference_dir}" 2>> {log}
+
+                # Force removal if needed
+                if [ -d "{params.reference_dir}" ]; then
+                    echo "Directory still exists, forcing removal..." >> {log}
+                    rm -rf "{params.reference_dir}" 2>> {log}
+                fi
+
+                if [ ! -d "{params.reference_dir}" ]; then
+                    echo "Successfully removed: {params.reference_dir}" >> {log}
+                else
+                    echo "WARNING: Failed to completely remove: {params.reference_dir}" >> {log}
+                    ls -la "{params.reference_dir}" 2>> {log} || echo "Cannot list directory contents" >> {log}
+                fi
+            else
+                echo "Reference directory does not exist: {params.reference_dir}" >> {log}
+            fi
+        fi
         """


### PR DESCRIPTION
## Summary
- remove the `processing/reference` directory in `copy_results_all` when `cleanup_processing` is enabled
- document that cleanup removes reference files
- improve cleanup script to verify removal of the reference directory

## Testing
- `snakemake --dry-run --config processing_dir="tests/test_counts/test_out/processing" results_dir="tests/test_counts/test_out/results" benchmark_dir="tests/test_counts/test_out/benchmarks" genome_index="tests/test_counts/genome/random_genome" gtf_file="tests/test_counts/genome/annotation.gtf" samples_csv="test_samples_counts_local.csv" cleanup_processing='True'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb5774cc88331a77a8c2e4d8b31d4