### PR TITLE
Add GitHub Actions dry-run workflow

### DIFF
--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.10
-
+          python-version: "3.10"
+      
       - name: Install Snakemake
-        run: conda install -c conda-forge -c bioconda snakemake
+        run: conda create -y -c conda-forge -c bioconda -n snakemake snakemake
 
       - name: Run Snakemake dry-run test
         run: |
-          snakemake --cores 10 --use-conda --dry-run --config \
+          conda run -n snakemake snakemake --cores 10 --use-conda --dry-run --config \
             processing_dir="tests/test_counts/test_out/processing" \
             results_dir="tests/test_counts/test_out/results" \
             benchmark_dir="tests/test_counts/test_out/benchmarks" \

--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -11,17 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.10
 
       - name: Install Snakemake
-        run: pip install --no-cache-dir snakemake
+        run: conda install -c conda-forge -c bioconda snakemake
 
       - name: Run Snakemake dry-run test
         run: |
-          snakemake --cores 10 --use-singularity --dry-run --config \
+          snakemake --cores 10 --use-conda --dry-run --config \
             processing_dir="tests/test_counts/test_out/processing" \
             results_dir="tests/test_counts/test_out/results" \
             benchmark_dir="tests/test_counts/test_out/benchmarks" \

--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -1,0 +1,36 @@
+name: Snakemake Dry Run
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: snakemake
+          python-version: 3.10
+          auto-activate-base: false
+          channels: bioconda,conda-forge,defaults
+
+      - name: Install Snakemake
+        shell: bash -l {0}
+        run: conda install -y snakemake
+
+      - name: Run Snakemake dry-run test
+        shell: bash -l {0}
+        run: |
+          snakemake --cores 10 --use-singularity --dry-run --config \
+            processing_dir="tests/test_counts/test_out/processing" \
+            results_dir="tests/test_counts/test_out/results" \
+            benchmark_dir="tests/test_counts/test_out/benchmarks" \
+            genome_index="tests/test_counts/genome/random_genome" \
+            gtf_file="tests/test_counts/genome/annotation.gtf" \
+            samples_csv="test_samples_counts.csv" \
+            cleanup_processing='True'

--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -11,20 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          activate-environment: snakemake
           python-version: 3.10
-          auto-activate-base: false
-          channels: bioconda,conda-forge,defaults
 
       - name: Install Snakemake
-        shell: bash -l {0}
-        run: conda install -y snakemake
+        run: pip install --no-cache-dir snakemake
 
       - name: Run Snakemake dry-run test
-        shell: bash -l {0}
         run: |
           snakemake --cores 10 --use-singularity --dry-run --config \
             processing_dir="tests/test_counts/test_out/processing" \


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that performs a Snakemake dry-run on every push and PR

## Testing
- `snakemake --cores 10 --use-singularity --dry-run --config processing_dir="tests/test_counts/test_out/processing" results_dir="tests/test_counts/test_out/results" benchmark_dir="tests/test_counts/test_out/benchmarks" genome_index="tests/test_counts/genome/random_genome" gtf_file="tests/test_counts/genome/annotation.gtf" samples_csv="test_samples_counts.csv" cleanup_processing='True'`

------
https://chatgpt.com/codex/tasks/task_e_686fd4d6d5d48331b9a8aea7d6ce15e4