### PR TITLE
Use Miniforge for Snakemake workflow

### DIFF
--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate snakemake
-          snakemake --cores 10 --use-singularity --dry-run --config \
+          snakemake --cores 10 --use-conda --dry-run --config \
             processing_dir="tests/test_counts/test_out/processing" \
             results_dir="tests/test_counts/test_out/results" \
             benchmark_dir="tests/test_counts/test_out/benchmarks" \

--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -11,19 +11,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Miniforge
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: "3.10"
-          miniforge-version: "latest"
-          miniforge-variant: "Mambaforge"
-      
-      - name: Install Snakemake
-        run: conda create -y -c conda-forge -c bioconda -n snakemake snakemake
+      - name: Install Miniforge and Snakemake
+        shell: bash -l {0}
+        run: |
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          conda activate
+          conda create -y -c conda-forge -c bioconda -n snakemake snakemake
+          conda activate snakemake
 
       - name: Run Snakemake dry-run test
+        shell: bash -l {0}
         run: |
-          conda run -n snakemake snakemake --cores 10 --use-conda --dry-run --config \
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          conda activate snakemake
+          snakemake --cores 10 --use-singularity --dry-run --config \
             processing_dir="tests/test_counts/test_out/processing" \
             results_dir="tests/test_counts/test_out/results" \
             benchmark_dir="tests/test_counts/test_out/benchmarks" \

--- a/.github/workflows/snakemake-dry-run.yml
+++ b/.github/workflows/snakemake-dry-run.yml
@@ -1,0 +1,33 @@
+name: Snakemake Dry Run
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Miniforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: "3.10"
+          miniforge-version: "latest"
+          miniforge-variant: "Mambaforge"
+      
+      - name: Install Snakemake
+        run: conda create -y -c conda-forge -c bioconda -n snakemake snakemake
+
+      - name: Run Snakemake dry-run test
+        run: |
+          conda run -n snakemake snakemake --cores 10 --use-conda --dry-run --config \
+            processing_dir="tests/test_counts/test_out/processing" \
+            results_dir="tests/test_counts/test_out/results" \
+            benchmark_dir="tests/test_counts/test_out/benchmarks" \
+            genome_index="tests/test_counts/genome/random_genome" \
+            gtf_file="tests/test_counts/genome/annotation.gtf" \
+            samples_csv="test_samples_counts.csv" \
+            cleanup_processing='True'


### PR DESCRIPTION
## Summary
- switch CI setup from Miniconda to Miniforge
- keep dedicated Snakemake environment
- run the dry-run test within that environment

## Testing
- `snakemake --cores 10 --use-conda --dry-run --config processing_dir="tests/test_counts/test_out/processing" results_dir="tests/test_counts/test_out/results" benchmark_dir="tests/test_counts/test_out/benchmarks" genome_index="tests/test_counts/genome/random_genome" gtf_file="tests/test_counts/genome/annotation.gtf" samples_csv="test_samples_counts.csv" cleanup_processing='True'` *(fails: conda command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686fd4d6d5d48331b9a8aea7d6ce15e4