### PR TITLE
Create sample directories only when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive RNA-seq analysis pipeline built with Snakemake that supports mul
 - **Containerized**: Singularity support
 - **Benchmarking**: Detailed performance metrics
 - **Modular design**: Rules are automatically included based on your data
+- **On-demand directories**: Sample folders are created only when processing starts and cleaned up when finished
 
 ## Pipeline Architecture
 
@@ -292,8 +293,9 @@ results/
 └── copy_complete_all.txt                  # Pipeline completion marker
 ```
 
-If `cleanup_processing` is enabled, the pipeline also removes the `processing/reference`
-directory after this marker file is written.
+If `cleanup_processing` is enabled, the pipeline removes each sample's processing
+directory after the results are copied. The `processing/reference` directory is
+also removed at the end of the run.
 
 ## Run Tags and Sample Grouping
 

--- a/rules/sample_utils.py
+++ b/rules/sample_utils.py
@@ -16,9 +16,6 @@ def ensure_directories_exist(config):
     # Reference directory in processing folder
     os.makedirs(os.path.join(config['processing_dir'], 'reference'), exist_ok=True)
     
-    # Create merged directory for run tag groups
-    os.makedirs(os.path.join(config['processing_dir'], 'merged'), exist_ok=True)
-    
     print(f"Created directory structure at {config['processing_dir']} and {config['results_dir']}")
 
 def copy_reference_files(config):
@@ -237,9 +234,8 @@ def load_samples(config):
                         print(f"Error: Run tag '{run_tag}' contains samples with different read types: {read_types}")
                         raise ValueError(f"Run tag '{run_tag}' contains samples with different read types: {read_types}")
             
-            # Create directories for run tags
+            # Report run tag information
             for run_tag in run_tags:
-                create_run_tag_directories(config, run_tag)
                 print(f"  Run tag: {run_tag} - Contains {len(run_tag_samples[run_tag])} samples: {', '.join(run_tag_samples[run_tag])}")
         else:
             # If no run tag column, each sample is its own effective sample
@@ -247,13 +243,12 @@ def load_samples(config):
             for sample in effective_samples:
                 run_tag_samples[sample] = [sample]
         
-        # Create directories for all samples
+        # Print summary of loaded samples
         print(f"Loaded {len(samples_df)} samples:")
         for sample, row in samples_df.iterrows():
             sample_type = row['read_type']
             source_type = row['source_type']
             print(f"  {sample}: {sample_type}, {source_type} source")
-            create_sample_directories(config, sample)
         
         return samples_df, run_tag_samples, run_tags, effective_samples
     


### PR DESCRIPTION
## Summary
- delay creation of sample and run tag directories until processing begins
- document on-demand directory creation and cleanup

## Testing
- `snakemake --cores 10 --use-conda --dry-run --config processing_dir="tests/test_counts/test_out/processing" results_dir="tests/test_counts/test_out/results" benchmark_dir="tests/test_counts/test_out/benchmarks" genome_index="tests/test_counts/genome/random_genome" gtf_file="tests/test_counts/genome/annotation.gtf" samples_csv="test_samples_counts.csv" cleanup_processing='True'` *(fails: conda not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710b5d138c8331b48372ac5934ea71