### PR TITLE
Implement SRA download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Your `samples.csv` file should include these columns:
 |--------|----------|-------------|
 | `sample_name` | Yes | Unique identifier for each sample |
 | `read_type` | Yes | One of: `paired`, `single`, `interleaved`, `nanopore` |
-| `source_type` | Yes | Either `local` or `ftp` |
+| `source_type` | Yes | `local`, `ftp`, or `sra_paired` |
 | `file_path_1` | Yes | Path to first/only FASTQ file |
 | `file_path_2` | Conditional | Path to second FASTQ file (required for `paired` only) |
 | `checksum_1` | Optional | MD5 checksum for file_path_1 |
@@ -183,6 +183,17 @@ illumina_se_01,single,ftp,ftp://server.com/sample2.fastq.gz,,xyz789,,experiment_
 interleaved_01,interleaved,local,/data/sample3_interleaved.fastq.gz,,mno345,,experiment_A
 nanopore_01,nanopore,local,/data/sample4_nanopore.fastq.gz,,pqr678,,long_read_set
 ```
+
+## Using SRA Data
+
+The pipeline can download reads directly from NCBI SRA. Set `source_type` to `sra_paired` and specify the accession in `file_path_1`:
+
+```csv
+sample_name,read_type,source_type,file_path_1,file_path_2,checksum_1,checksum_2
+MySRA,paired,sra_paired,SRR12345678,,,
+```
+
+SRA reads are downloaded with `fastq-dump`, reformatted, and gzipped before entering the standard workflow.
 
 ## Processing Differences by Data Type
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ MySRA,paired,sra_paired,SRR12345678,,,
 ```
 
 SRA reads are downloaded with `fasterq-dump`, reformatted, and gzipped before entering the standard workflow.
+Each download touches a `.download_complete` file to signal that the FASTQ files are fully written before validation and further processing.
 
 ## Processing Differences by Data Type
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ sample_name,read_type,source_type,file_path_1,file_path_2,checksum_1,checksum_2
 MySRA,paired,sra_paired,SRR12345678,,,
 ```
 
-SRA reads are downloaded with `fastq-dump`, reformatted, and gzipped before entering the standard workflow.
+SRA reads are downloaded with `fasterq-dump`, reformatted, and gzipped before entering the standard workflow.
 
 ## Processing Differences by Data Type
 

--- a/Snakefile
+++ b/Snakefile
@@ -116,6 +116,7 @@ for sample in SAMPLES:
 # Categorize samples by type
 PAIRED_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'paired') and (SAMPLES_DF.loc[s, 'source_type'] == 'local')]
 PAIRED_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'paired') and (SAMPLES_DF.loc[s, 'source_type'] == 'ftp')]
+SRA_PAIRED_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'paired') and (SAMPLES_DF.loc[s, 'source_type'] == 'sra_paired')]
 SINGLE_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] in ['single', 'interleaved']) and (SAMPLES_DF.loc[s, 'source_type'] == 'local')]
 SINGLE_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] in ['single', 'interleaved']) and (SAMPLES_DF.loc[s, 'source_type'] == 'ftp')]
 NANOPORE_LOCAL_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] == 'nanopore') and (SAMPLES_DF.loc[s, 'source_type'] == 'local')]
@@ -124,6 +125,7 @@ NANOPORE_FTP_SAMPLES = [s for s in SAMPLES if (SAMPLES_DF.loc[s, 'read_type'] ==
 # Print sample categorization
 print(f"Paired-end, local samples: {len(PAIRED_LOCAL_SAMPLES)}")
 print(f"Paired-end, FTP samples: {len(PAIRED_FTP_SAMPLES)}")
+print(f"Paired-end, SRA samples: {len(SRA_PAIRED_SAMPLES)}")
 print(f"Single-end/Interleaved, local samples: {len(SINGLE_LOCAL_SAMPLES)}")
 print(f"Single-end/Interleaved, FTP samples: {len(SINGLE_FTP_SAMPLES)}")
 print(f"Nanopore, local samples: {len(NANOPORE_LOCAL_SAMPLES)}")
@@ -171,6 +173,9 @@ if PAIRED_LOCAL_SAMPLES:
 if PAIRED_FTP_SAMPLES:
     include: "rules/acquisition/ftp_paired.smk"
 
+if SRA_PAIRED_SAMPLES:
+    include: "rules/acquisition/sra_paired.smk"
+
 if len(SINGLE_LOCAL_SAMPLES) + len(NANOPORE_LOCAL_SAMPLES) > 0:
     include: "rules/acquisition/local_single.smk"
 
@@ -185,7 +190,7 @@ if len(SINGLE_LOCAL_SAMPLES) + len(SINGLE_FTP_SAMPLES) + len(NANOPORE_LOCAL_SAMP
     include: "rules/checksum/single_checksum.smk"
 
 # Quality filtering rules
-if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len([
+if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len(SRA_PAIRED_SAMPLES) + len([
     s for s in SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved'
 ]) > 0:
     include: "rules/fastp/paired_fastp.smk"
@@ -198,7 +203,7 @@ if any(SAMPLES_DF.loc[s, 'read_type'] == 'interleaved' for s in SAMPLES):
     include: "rules/fastp/split_interleaved.smk"
 
 # Alignment rules
-if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len([s for s in SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved']) > 0:
+if len(PAIRED_LOCAL_SAMPLES) + len(PAIRED_FTP_SAMPLES) + len(SRA_PAIRED_SAMPLES) + len([s for s in SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved']) > 0:
     include: "rules/alignment/paired_align.smk"
 
 if len([s for s in SINGLE_LOCAL_SAMPLES + SINGLE_FTP_SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'single']) > 0:

--- a/envs/sra.yaml
+++ b/envs/sra.yaml
@@ -1,8 +1,10 @@
-name: base
+name: sra
 channels:
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
-  - coreutils
+  - sra-tools=3.0.3
+  - pigz
   - gzip
   - awk

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -10,7 +10,8 @@ rule download_sra:
         sample = "|".join([re.escape(s) for s in SRA_PAIRED_SAMPLES])
     output:
         r1 = temp(get_processing_path("{sample}/sra_download/{sample}_1.fastq")),
-        r2 = temp(get_processing_path("{sample}/sra_download/{sample}_2.fastq"))
+        r2 = temp(get_processing_path("{sample}/sra_download/{sample}_2.fastq")),
+        flag = get_processing_path("{sample}/sra_download/.download_complete")
     params:
         accession = lambda w: SAMPLES_DF.loc[w.sample, 'file_path_1'],
         outdir = lambda w: get_processing_path(f"{w.sample}/sra_download"),
@@ -32,13 +33,15 @@ rule download_sra:
             mv {params.outdir}/{params.accession}_1.fastq {output.r1}
             mv {params.outdir}/{params.accession}_2.fastq {output.r2}
         fi
+        touch {output.flag}
         """
 
 # Validate SRA download
 rule validate_sra_download:
     input:
         r1 = get_processing_path("{sample}/sra_download/{sample}_1.fastq"),
-        r2 = get_processing_path("{sample}/sra_download/{sample}_2.fastq")
+        r2 = get_processing_path("{sample}/sra_download/{sample}_2.fastq"),
+        done = get_processing_path("{sample}/sra_download/.download_complete")
     output:
         flag = get_processing_path("{sample}/sra_download/.validated")
     conda:

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -2,9 +2,12 @@
 Rules for downloading paired-end reads directly from NCBI SRA
 """
 import os
+import re
 
 # Download FASTQ files from SRA
 rule download_sra:
+    wildcard_constraints:
+        sample = "|".join([re.escape(s) for s in SRA_PAIRED_SAMPLES])
     output:
         r1 = temp(get_processing_path("{sample}/sra_download/{sample}_1.fastq")),
         r2 = temp(get_processing_path("{sample}/sra_download/{sample}_2.fastq"))
@@ -64,8 +67,8 @@ rule reformat_sra_headers:
         r2 = temp(get_processing_path("{sample}/sra_reformatted/{sample}_2.fq"))
     shell:
         """
-        awk '{print (NR%4==1) ? "@1_" ++i " READ/1" : $0}' {input.r1} > {output.r1}
-        awk '{print (NR%4==1) ? "@1_" ++i " READ/2" : $0}' {input.r2} > {output.r2}
+        awk '{{print (NR%4==1) ? "@1_" ++i " READ/1" : $0}}' {input.r1} > {output.r1}
+        awk '{{print (NR%4==1) ? "@1_" ++i " READ/2" : $0}}' {input.r2} > {output.r2}
         """
 
 # Compress reformatted files

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -21,6 +21,8 @@ rule download_sra:
     retries: 3
     conda:
         "../../envs/sra.yaml"
+    singularity:
+        config.get("singularity_image", "")
     shell:
         """
         mkdir -p {params.outdir} {params.tmpdir}
@@ -37,6 +39,10 @@ rule validate_sra_download:
         r2 = get_processing_path("{sample}/sra_download/{sample}_2.fastq")
     output:
         flag = get_processing_path("{sample}/sra_download/.validated")
+    conda:
+        "../../envs/core.yaml"
+    singularity:
+        config.get("singularity_image", "")
     run:
         if os.path.getsize(input.r1) == 0 or os.path.getsize(input.r2) == 0:
             raise ValueError(f"Empty files downloaded for {wildcards.sample}")
@@ -56,6 +62,10 @@ rule reformat_sra_headers:
     output:
         r1 = temp(get_processing_path("{sample}/sra_reformatted/{sample}_1.fq")),
         r2 = temp(get_processing_path("{sample}/sra_reformatted/{sample}_2.fq"))
+    conda:
+        "../../envs/core.yaml"
+    singularity:
+        config.get("singularity_image", "")
     shell:
         """
         awk '{{print (NR%4==1) ? "@1_" ++i " READ/1" : $0}}' {input.r1} > {output.r1}
@@ -73,6 +83,8 @@ rule gzip_sra_fastq:
     threads: 4
     conda:
         "../../envs/core.yaml"
+    singularity:
+        config.get("singularity_image", "")
     shell:
         """
         gzip -c {input.r1} > {output.r1}

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -1,0 +1,86 @@
+"""
+Rules for downloading paired-end reads directly from NCBI SRA
+"""
+import os
+
+# Download FASTQ files from SRA
+rule download_sra:
+    output:
+        r1 = temp(get_processing_path("{sample}/sra_download/{sample}_1.fastq")),
+        r2 = temp(get_processing_path("{sample}/sra_download/{sample}_2.fastq"))
+    params:
+        accession = lambda w: SAMPLES_DF.loc[w.sample, 'file_path_1'],
+        outdir = lambda w: get_processing_path(f"{w.sample}/sra_download")
+    log:
+        get_processing_path("{sample}/logs/sra_download.log")
+    threads: 8
+    retries: 3
+    conda:
+        "../../envs/sra.yaml"
+    shell:
+        """
+        mkdir -p {params.outdir}
+        fastq-dump \
+            --split-3 \
+            --threads {threads} \
+            --outdir {params.outdir} \
+            --skip-technical \
+            --clip \
+            --read-filter pass \
+            --qual-filter \
+            --split-spot \
+            --defline-seq '@$ac.$si.$sg/$ri' \
+            --defline-qual '+' \
+            {params.accession}
+        mv {params.outdir}/{params.accession}_1.fastq {output.r1}
+        mv {params.outdir}/{params.accession}_2.fastq {output.r2}
+        """
+
+# Validate SRA download
+rule validate_sra_download:
+    input:
+        r1 = get_processing_path("{sample}/sra_download/{sample}_1.fastq"),
+        r2 = get_processing_path("{sample}/sra_download/{sample}_2.fastq")
+    output:
+        flag = get_processing_path("{sample}/sra_download/.validated")
+    run:
+        if os.path.getsize(input.r1) == 0 or os.path.getsize(input.r2) == 0:
+            raise ValueError(f"Empty files downloaded for {wildcards.sample}")
+        with open(input.r1) as f1, open(input.r2) as f2:
+            lines1 = sum(1 for _ in f1)
+            lines2 = sum(1 for _ in f2)
+            if lines1 != lines2:
+                raise ValueError(f"Unequal read counts: R1={lines1/4}, R2={lines2/4}")
+        open(output.flag, 'w').close()
+
+# Reformat headers
+rule reformat_sra_headers:
+    input:
+        r1 = get_processing_path("{sample}/sra_download/{sample}_1.fastq"),
+        r2 = get_processing_path("{sample}/sra_download/{sample}_2.fastq"),
+        valid = get_processing_path("{sample}/sra_download/.validated")
+    output:
+        r1 = temp(get_processing_path("{sample}/sra_reformatted/{sample}_1.fq")),
+        r2 = temp(get_processing_path("{sample}/sra_reformatted/{sample}_2.fq"))
+    shell:
+        """
+        awk '{print (NR%4==1) ? "@1_" ++i " READ/1" : $0}' {input.r1} > {output.r1}
+        awk '{print (NR%4==1) ? "@1_" ++i " READ/2" : $0}' {input.r2} > {output.r2}
+        """
+
+# Compress reformatted files
+rule gzip_sra_fastq:
+    input:
+        r1 = get_processing_path("{sample}/sra_reformatted/{sample}_1.fq"),
+        r2 = get_processing_path("{sample}/sra_reformatted/{sample}_2.fq")
+    output:
+        r1 = get_processing_path("{sample}/{sample}_R1.fastq.gz"),
+        r2 = get_processing_path("{sample}/{sample}_R2.fastq.gz")
+    threads: 4
+    conda:
+        "../../envs/core.yaml"
+    shell:
+        """
+        gzip -c {input.r1} > {output.r1}
+        gzip -c {input.r2} > {output.r2}
+        """

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -13,7 +13,8 @@ rule download_sra:
         r2 = temp(get_processing_path("{sample}/sra_download/{sample}_2.fastq"))
     params:
         accession = lambda w: SAMPLES_DF.loc[w.sample, 'file_path_1'],
-        outdir = lambda w: get_processing_path(f"{w.sample}/sra_download")
+        outdir = lambda w: get_processing_path(f"{w.sample}/sra_download"),
+        tmpdir = lambda w: get_processing_path(f"{w.sample}/sra_tmp")
     log:
         get_processing_path("{sample}/logs/sra_download.log")
     threads: 8
@@ -22,19 +23,9 @@ rule download_sra:
         "../../envs/sra.yaml"
     shell:
         """
-        mkdir -p {params.outdir}
-        fastq-dump \
-            --split-3 \
-            --threads {threads} \
-            --outdir {params.outdir} \
-            --skip-technical \
-            --clip \
-            --read-filter pass \
-            --qual-filter \
-            --split-spot \
-            --defline-seq '@$ac.$si.$sg/$ri' \
-            --defline-qual '+' \
-            {params.accession}
+        mkdir -p {params.outdir} {params.tmpdir}
+        fasterq-dump --threads {threads} --split-files \
+            --outdir {params.outdir} --temp {params.tmpdir} {params.accession}
         mv {params.outdir}/{params.accession}_1.fastq {output.r1}
         mv {params.outdir}/{params.accession}_2.fastq {output.r2}
         """

--- a/rules/acquisition/sra_paired.smk
+++ b/rules/acquisition/sra_paired.smk
@@ -28,8 +28,10 @@ rule download_sra:
         mkdir -p {params.outdir} {params.tmpdir}
         fasterq-dump --threads {threads} --split-files \
             --outdir {params.outdir} --temp {params.tmpdir} {params.accession}
-        mv {params.outdir}/{params.accession}_1.fastq {output.r1}
-        mv {params.outdir}/{params.accession}_2.fastq {output.r2}
+        if [ "{params.accession}" != "{wildcards.sample}" ]; then
+            mv {params.outdir}/{params.accession}_1.fastq {output.r1}
+            mv {params.outdir}/{params.accession}_2.fastq {output.r2}
+        fi
         """
 
 # Validate SRA download

--- a/rules/alignment/paired_align.smk
+++ b/rules/alignment/paired_align.smk
@@ -32,7 +32,19 @@ def get_align_input(wildcards):
 # Rule for aligning paired-end and split interleaved reads with bowtie2
 rule align_paired_end:
     wildcard_constraints:
-        sample = "|".join([re.escape(s) for s in PAIRED_LOCAL_SAMPLES + PAIRED_FTP_SAMPLES + [s for s in SAMPLES if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved']])
+        sample = "|".join(
+            [
+                re.escape(s)
+                for s in PAIRED_LOCAL_SAMPLES
+                + PAIRED_FTP_SAMPLES
+                + SRA_PAIRED_SAMPLES
+                + [
+                    s
+                    for s in SAMPLES
+                    if SAMPLES_DF.loc[s, 'read_type'] == 'interleaved'
+                ]
+            ]
+        )
     input:
         unpack(get_align_input)
     output:

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -119,6 +119,25 @@ def get_nanopore_fastq(wildcards):
     sample = wildcards.sample
     return get_processing_path(f"{sample}/{sample}.fastq.gz")
 
+# Generic helper for determining fastp input based on source type
+def get_fastp_input(wildcards):
+    """Return the R1/R2 files for fastp based on sample source"""
+    sample = wildcards.sample
+    source_type = get_source_type(sample)
+    if source_type == "sra_paired":
+        return {
+            "r1": get_processing_path(f"{sample}/{sample}_R1.fastq.gz"),
+            "r2": get_processing_path(f"{sample}/{sample}_R2.fastq.gz"),
+        }
+    return {
+        "r1": get_processing_path(f"{sample}/{sample}.1.fastq.gz"),
+        "r2": get_processing_path(f"{sample}/{sample}.2.fastq.gz"),
+    }
+
+def skip_md5_for_sra(wildcards):
+    """Return True if MD5 checks should be skipped for this sample"""
+    return get_source_type(wildcards.sample) == "sra_paired"
+
 # Helper functions for accessing cleaned FASTQ files (after fastp)
 def get_cleaned_fastq_r1(wildcards):
     """Get the cleaned R1 fastq file for a paired-end sample"""

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -44,7 +44,7 @@ def get_read_type(sample):
         return 'paired'
 
 def get_source_type(sample):
-    """Return 'local' or 'ftp' for a sample"""
+    """Return the source_type for a sample (e.g. 'local', 'ftp', 'sra_paired')"""
     try:
         return SAMPLES_DF.loc[sample, 'source_type']
     except Exception as e:

--- a/rules/fastp/paired_fastp.smk
+++ b/rules/fastp/paired_fastp.smk
@@ -10,9 +10,9 @@ def is_interleaved_sample(sample):
 # Rule for fastp processing of paired-end and split interleaved reads
 rule fastp_paired_end:
     input:
-        r1 = lambda wc: get_processing_path(f"{wc.sample}/{wc.sample}.1.fastq.gz"),
-        r2 = lambda wc: get_processing_path(f"{wc.sample}/{wc.sample}.2.fastq.gz"),
-        checksums = lambda wc: get_processing_path(f"{wc.sample}/checksums_paired_verified.flag") if not is_interleaved_sample(wc.sample) else []
+        r1 = lambda wc: get_fastp_input(wc)["r1"],
+        r2 = lambda wc: get_fastp_input(wc)["r2"],
+        checksums = lambda wc: [] if skip_md5_for_sra(wc) or is_interleaved_sample(wc.sample) else get_processing_path(f"{wc.sample}/checksums_paired_verified.flag")
     params:
         split_complete = lambda wc: get_processing_path(f"{wc.sample}/split_interleaved_complete.flag") if is_interleaved_sample(wc.sample) else ""
     output:

--- a/rules/sample_utils.py
+++ b/rules/sample_utils.py
@@ -159,7 +159,7 @@ def load_samples(config):
             raise ValueError(f"Invalid read_type values: {', '.join(map(str, invalid_read_types))}. Must be one of: {', '.join(valid_read_types)}")
         
         # Validate source_type values
-        valid_source_types = ['local', 'ftp']
+        valid_source_types = ['local', 'ftp', 'sra_paired']
         invalid_source_types = samples_df[~samples_df['source_type'].isin(valid_source_types)]['source_type'].unique()
         
         if len(invalid_source_types) > 0:
@@ -169,9 +169,14 @@ def load_samples(config):
         # Validate file paths based on read type and source type
         for idx, row in samples_df.iterrows():
             if row['read_type'] == 'paired':
-                if pd.isna(row.get('file_path_1', None)) or pd.isna(row.get('file_path_2', None)):
-                    print(f"Error: Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
-                    raise ValueError(f"Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
+                if row['source_type'] == 'sra_paired':
+                    if pd.isna(row.get('file_path_1', None)):
+                        print(f"Error: Missing SRA accession for sample {row['sample_name']}")
+                        raise ValueError(f"Missing SRA accession for sample {row['sample_name']}")
+                else:
+                    if pd.isna(row.get('file_path_1', None)) or pd.isna(row.get('file_path_2', None)):
+                        print(f"Error: Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
+                        raise ValueError(f"Missing file_path_1 or file_path_2 for paired-end sample {row['sample_name']}")
             else:  # single-end, interleaved, or nanopore
                 if pd.isna(row.get('file_path_1', None)):
                     print(f"Error: Missing file_path_1 for {row['read_type']} sample {row['sample_name']}")


### PR DESCRIPTION
## Summary
- add SRA environment with `sra-tools`
- download SRA reads and reformat headers
- skip checksum step for SRA and use new helper functions
- include SRA samples in Snakefile logic
- document SRA usage in README

## Testing
- `snakemake -n` *(fails: Genome index not found)*

------
https://chatgpt.com/codex/tasks/task_e_687226dd23f48331b2665e120ae8d611