### PR TITLE
docs: highlight VSG meta-analysis use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RNA-seq Snakemake Pipeline
 
-A comprehensive RNA-seq analysis pipeline built with Snakemake that supports multiple data types including paired-end, single-end, and nanopore sequencing data.
+A comprehensive RNA-seq analysis pipeline built with Snakemake that supports multiple data types including paired-end, single-end, and nanopore sequencing data. The workflow has been used in production for [A Meta-Analysis of VSG Expression](https://vsgs-web-server.pages.dev/) where we reanalyzed 454 RNA-seq runs (168 single-end, 280 paired-end, and 6 nanopore datasets) drawn from 31 publications, spanning 35 experimental factors across 78 experiments.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- reference the VSG expression meta-analysis web resource in the README introduction
- document the pipeline's use for reanalysing 454 RNA-seq runs spanning single-end, paired-end, and nanopore data

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce9cd869a48331a0f39a302f585c9c