### PR TITLE
Document VSG meta-analysis use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive RNA-seq analysis pipeline built with Snakemake that supports multiple data types including paired-end, single-end, and nanopore sequencing data.
 
+The workflow powers large-scale studies such as the [VSG expression meta-analysis](https://vsgs-web-server.pages.dev/) where we reprocessed 454 RNA-seq runs (168 single-end, 280 paired-end, 6 nanopore datasets) drawn from 31 publications, spanning 35 experimental factors across 78 experiments.
+
 ## Features
 
 - **Multi-format support**: Paired-end, single-end and nanopore data


### PR DESCRIPTION
## Summary
- mention that the Snakemake RNA-seq pipeline powers the VSG expression meta-analysis
- link to the VSGS web portal and enumerate the scope of the reprocessed datasets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cea092ab688331a3575176a190e44d