### PR TITLE
docs: highlight VSG meta-analysis use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive RNA-seq analysis pipeline built with Snakemake that supports multiple data types including paired-end, single-end, and nanopore sequencing data.
 
+This workflow powered the [Meta-Analysis of VSG Expression](https://vsgs-web-server.pages.dev/) reanalyzing 454 RNA-seq runs (168 single-end, 280 paired-end, and 6 nanopore datasets) from 31 publications, spanning 35 experimental factors across 78 experiments.
+
 ## Features
 
 - **Multi-format support**: Paired-end, single-end and nanopore data


### PR DESCRIPTION
## Summary
- mention that the Snakemake workflow powered the Meta-Analysis of VSG Expression study
- link to the public site that showcases the reanalysis of 454 RNA-seq runs across multiple data types

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68ceaaa32db88331ac61b15fda73f84c